### PR TITLE
Fix test noise and maintain sale lookup message

### DIFF
--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/GetSaleByNumber/GetSaleByNumberHandler.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/GetSaleByNumber/GetSaleByNumberHandler.cs
@@ -26,7 +26,7 @@ namespace Ambev.DeveloperEvaluation.Application.Sales.GetSaleByNumber
             var sale = await _saleRepository.GetBySaleNumberAsync(request.SaleNumber, cancellationToken);
 
             if (sale == null)
-                throw new KeyNotFoundException($"Sale with mumber [{request.SaleNumber}] not found.");
+                throw new KeyNotFoundException($"Sale with number [{request.SaleNumber}] not found.");
 
             return _mapper.Map<GetSaleByNumberResult>(sale);
         }

--- a/template/backend/src/Ambev.DeveloperEvaluation.Common/Security/AuthenticationExtension.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Common/Security/AuthenticationExtension.cs
@@ -37,8 +37,6 @@ namespace Ambev.DeveloperEvaluation.Common.Security
                 };
             });
 
-            services.AddScoped<IJwtTokenGenerator, JwtTokenGenerator>();
-
             return services;
         }
     }

--- a/template/backend/tests/Ambev.DeveloperEvaluation.Unit/Application/CreateSaleHandlerTests.cs
+++ b/template/backend/tests/Ambev.DeveloperEvaluation.Unit/Application/CreateSaleHandlerTests.cs
@@ -43,17 +43,6 @@ namespace Ambev.DeveloperEvaluation.Unit.Application
             // Arrange
             var command = CreateSaleHandlerTestData.GenerateValidCommand();
 
-            var validator = new CreateSaleValidator();
-            var validation = validator.Validate(command);
-            Console.WriteLine(validation.ToString());
-
-            foreach (var item in command.Items)
-            {
-                Console.WriteLine($"Item: ProductId={item.ProductId}, Qty={item.Quantity}, Price={item.UnitPrice}");
-            }
-            Console.WriteLine($"CustomerName={command.CustomerName}, BranchName={command.BranchName}");
-
-
             _saleRepositoryMock
                 .Setup(repo => repo.GetBySaleNumberAsync(command.SaleNumber, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((Sale?)null); // No duplicate


### PR DESCRIPTION
## Summary
- remove console debugging from CreateSaleHandlerTests
- keep sale lookup error message consistent
- keep unique registration for JWT token generator

## Testing
- `dotnet test template/backend/tests/Ambev.DeveloperEvaluation.Unit/Ambev.DeveloperEvaluation.Unit.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843bb2c4ddc832a93ae4cb463b6756b